### PR TITLE
GraphEditor performance updates v1

### DIFF
--- a/IGraphM/GraphEditor.m
+++ b/IGraphM/GraphEditor.m
@@ -91,7 +91,8 @@ Interpretation[
   }
 , refresh[] := Module[{temp}
   , Catch[
-      If[ Needs@"IGraphM`" === $Failed, Throw[ error = packageFailure]]
+      error = False
+    ; If[ Needs@"IGraphM`" === $Failed, Throw[ error = packageFailure]]
 
     ; temp = geStateVersionCheck @ state
     ; If[ AssociationQ @ temp, state = temp, Throw[ error = temp] ]
@@ -464,18 +465,23 @@ Table[
 ]
 
 
-geEdgeShapeFunction[Dynamic @ state_, e_Association] :=
-With[
-  {
-    nef = $edgeThickness,
-    aef = $activeEdgeThickness
-  },
-  EventHandler[
-      { AbsoluteThickness @  Dynamic[ FEPrivate`If[  FrontEnd`CurrentValue["MouseOver"], aef, nef ] ]
-      , edgeToPrimitive @ e
-      }
+geEdgeShapeFunction[Dynamic @ state_, e_Association] := EventHandler[
+    edgeHoverWrapper @ edgeToPrimitive @ e      
   , { "MouseClicked" :> (geAction["EdgeClicked", Dynamic @ state, e]) }
   , PassEventsUp -> False (* edgeclicked should not be followed by outer mouseclicked*)
+  ]
+
+
+edgeHoverWrapper[primitive_]:=  {
+  AbsoluteThickness @  Dynamic[ FEPrivate`If[  FrontEnd`CurrentValue["MouseOver"], $activeEdgeThickness, $edgeThickness ] ]
+, primitive
+}
+
+
+If[ $VersionNumber > 12
+, edgeHoverWrapper[primitive_Arrow]:=  Mouseover[
+    {AbsoluteThickness @ $edgeThickness, primitive},
+    {AbsoluteThickness @ $activeEdgeThickness, primitive}
   ]
 ]
 

--- a/IGraphM/GraphEditor.m
+++ b/IGraphM/GraphEditor.m
@@ -69,7 +69,7 @@ iGraphEditor // Options = Options @ IGGraphEditor;
 supportedGraphQ = ! MixedGraphQ[#] && SimpleGraphQ[#]&;
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*iGraphEditor*)
 
 
@@ -166,7 +166,7 @@ iGraphEditorPanel[Dynamic@state_] := EventHandler[
 (*State*)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*state version*)
 
 
@@ -199,7 +199,7 @@ geStateVersionCheck[___] :=
   Failure["GraphEditor", <|"MessageTemplate" -> IGGraphEditor::unknownState|>]
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*from state*)
 
 
@@ -228,7 +228,7 @@ GraphFromEditorState[state_, $stateVersion] := Module[{v, e, pos, graph}
 ]
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*to state*)
 
 
@@ -357,7 +357,7 @@ stateHasCurvedEdges[state_Association]:= state[ "DirectedEdges"]
 (*graphics*)
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*geGraphics*)
 
 
@@ -533,7 +533,7 @@ geHighlightsPrimitives[Dynamic @ state_] := With[{ selV := state["selectedVertex
 (*UI Actions*)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*$geDebug*)
 
 
@@ -611,7 +611,7 @@ geAction["UpdateRange", Dynamic @ state_] := Module[
 ; state = stateHandleNarrowRange @ state
 
 ; state[  "aspectRatio"] = #/#2& @@ (#2-#& @@@ state[ "range"])
-; state[  "ImageSize" ] = {1, 1/state[  "aspectRatio"]} * If[ListQ@#, First@#,#]& @ state[ "ImageSize"]
+; state[  "ImageSize" ] = {1, 1/state[  "aspectRatio"]} * If[ListQ@#, First@#,# /. Automatic -> 300]& @ state[ "ImageSize"] 
 ; state[  "inRangeQ" ] = RegionMember[ Rectangle @@ Transpose@ state[  "range"] ]
 ; geAction["UpdateVertexSize", Dynamic @ state]
 ]
@@ -717,7 +717,7 @@ geAction["Select", Dynamic @ state_, vId_String] := state["selectedVertex"] = vI
 geAction["Unselect", Dynamic @ state_] := state["selectedVertex"] = Null
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*AddVertex*)
 
 
@@ -790,15 +790,15 @@ geAction["CreateEdge", Dynamic @ state_, selectedV_String, clickedV_String] := M
   ; Message[IGGraphEditor::multiEdge]
   ; Return[$Failed, Module]
   ]
+; eId = CreateUUID["e-"]
 
-; eId = "e"<>ToString[++state[ "eCounter"]]
 ; type =   If[state["DirectedEdges"], Rule, UndirectedEdge]
 
 ; state["edge", eId ] = createEdge[eId,  type[selectedV, clickedV] ]
+; state["eCounter"]++
 
 ; geAction["Unselect", Dynamic @ state]
 ; geAction["UpdateEdgesShapes", Dynamic @ state]
-
 ]
 
 
@@ -825,7 +825,7 @@ geAction["ToggleEdgeType", Dynamic@state_, edge_] := With[{ type := state["edge"
 (nextEdgeType[#]=#2)& @@@ Partition[{UndirectedEdge["v1", "v2"], "v1"->"v2", "v2"->"v1"}, 2, 1, {1, 1}]
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*UpdateEdgesShapes*)
 
 
@@ -841,6 +841,9 @@ geAction["UpdateEdgesShapes", _ @ state_] := Module[{primitives,  vertexEncoded,
   ]
 
 ; ( state["edge", #id, "shape"] = ToEdgeShapeFunction[#primitive, vertexEncoded] )& /@ primitives
+(* nested tracking is not supported yet so we need to manually trigger all edges update 
+   we keep using eCounter for triggers because general mutations of .edges should not trigger updates *)
+; IGraphM`PreciseTracking`PackagePrivate`UpdateTarget[state["eCounter"]]
 ]
 
 
@@ -867,7 +870,7 @@ ToEdgeShapeFunction[Arrow[b_BezierCurve, ___], vertexEncoded_] := Arrow[b /. ver
 ToEdgeShapeFunction[p_, ___] := Automatic;
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*helpers*)
 
 

--- a/IGraphM/GraphEditor.m
+++ b/IGraphM/GraphEditor.m
@@ -11,6 +11,8 @@ Package["IGraphM`"]
 
 PackageExport["IGGraphEditor"]
 
+
+(*PDynamic = Dynamic*)
 (* Dev notes
  - foo[ Dynamic @ state_ ] is no better than HoldFirst etc. I just like this convention for GUI
  - state should not be modified during continuous actions
@@ -70,6 +72,7 @@ supportedGraphQ = ! MixedGraphQ[#] && SimpleGraphQ[#]&;
 (* ::Subsection::Closed:: *)
 (*iGraphEditor*)
 
+
 editorFailure[ msg_String ] := Failure[
   "GraphEditor"
 , <|"Message" -> "\[WarningSign] "<> msg |>
@@ -79,7 +82,6 @@ iGraphEditor[graph:((_? supportedGraphQ)|PatternSequence[]), opt:OptionsPattern[
 With[
   {
     packageFailure = editorFailure["Failed to load IGraphM`, make sure it is installed."]
-  , performanceFailure = editorFailure["Too many vertices and edges. Increase \"PerformanceLimit\" option to try anyway."]
   },
 Interpretation[
   {
@@ -87,35 +89,18 @@ Interpretation[
   , error = False
   , refresh
   }
-, refresh[] := Module[{temp}, Catch[
-    If[
-      Needs@"IGraphM`" === $Failed
-    , Throw[ error = packageFailure]
+, refresh[] := Module[{temp}
+  , Catch[
+      If[ Needs@"IGraphM`" === $Failed, Throw[ error = packageFailure]]
+
+    ; temp = geStateVersionCheck @ state
+    ; If[ AssociationQ @ temp, state = temp, Throw[ error = temp] ]
+
+    ; iGraphEditorInitialization[state, error]  (*can throw*)  
     ]
+  ]
 
-  ; temp = geStateVersionCheck @ state
-  ; If[ AssociationQ @ temp
-    , state = temp
-    , Throw[ error = temp]
-    ]
-
-  ; If[
-      state["config", "vCounter"] + state["config", "eCounter"] > state["config", "PerformanceLimit"]
-    , Throw[ error =  performanceFailure]
-    ]
-
-  ; error = False
-
-  ; geAction["UpdateVertexSize", Hold @ state]
-  ; geAction["UpdateEdgesShapes", Hold @ state]
-    (*(Hold) is there to workaround a bug with Interpretation's Initialization
-      which inserts evaluated Dynamic's arguments
-    *)
-
-  ]]
-
-;
-  PaneSelector[
+; PaneSelector[
   {
     True -> Button[Dynamic @ error,  refresh[], BaseStyle -> 15]
   , False -> Panel[
@@ -131,8 +116,33 @@ Interpretation[
 , GraphFromEditorState @ state
 
 , Initialization :> refresh[]
+, Deinitialization :> iGraphEditorDeinitialization[state]
 
 ]]
+
+
+iGraphEditorInitialization // Attributes = {HoldAll}
+iGraphEditorInitialization[state_, error_]:=Module[
+  {perfFailure = editorFailure["Too many vertices and edges. Increase \"PerformanceLimit\" option to try anyway."]}
+  
+, If[
+    state[ "vCounter"] + state[ "eCounter"] > state[ "PerformanceLimit"]
+  , Throw[ error =  perfFailure ]
+  ]
+
+; ToTrackedAssociation @ state
+  
+; geAction["UpdateVertexSize", Hold @ state]
+; geAction["UpdateEdgesShapes", Hold @ state]
+    (*(Hold) is there to workaround a bug with Interpretation's Initialization
+      which inserts evaluated Dynamic's arguments
+    *)
+    
+; {}
+]
+
+iGraphEditorDeinitialization // Attributes = {HoldAll}
+iGraphEditorDeinitialization[state_]:= StopTracking @ state
 
 
 iGraphEditor[_Graph, OptionsPattern[]] := Failure["GraphEditor", <|"Message" -> "The input graph must be simple and must not be mixed."|>]
@@ -149,12 +159,209 @@ iGraphEditorPanel[Dynamic@state_] := EventHandler[
   , PassEventsDown -> True
   ]
 
+
+
+(* ::Subsection:: *)
+(*State*)
+
+
+(* ::Subsubsection:: *)
+(*state version*)
+
+
+$stateVersion = 2;
+(*It does not change unless the structure of state association is changed.
+  That implies new geActions etc won't be compatible with old state *)
+
+
+(*ONCE $stateVersion > 1 *)
+(*
+  geStateVersionCheck[ state : KeyValuePattern[{"version" \[Rule] oldVersion}] ] := (*oldVersion to oldVersion+1 transition rules*)
+*)
+
+
+geStateVersionCheck[ state : KeyValuePattern[{"version" -> $stateVersion}] ] := state
+
+
+geStateVersionCheck[ state : KeyValuePattern[{"version" -> 1}] ]:= <|
+  state // KeyDrop["config"]
+, state["config"] 
+, "version" -> 2
+|>
+
+
+geStateVersionCheck[ state : KeyValuePattern[{"version" -> v_}] ] :=
+  Failure["GraphEditor", <|"MessageTemplate" -> IGGraphEditor::oldVer|>]
+
+
+geStateVersionCheck[___] :=
+  Failure["GraphEditor", <|"MessageTemplate" -> IGGraphEditor::unknownState|>]
+
+
+(* ::Subsubsection:: *)
+(*from state*)
+
+
+GraphFromEditorState[state_Association] := GraphFromEditorState[geStateVersionCheck @ state, $stateVersion];
+
+
+GraphFromEditorState[state_, $stateVersion] := Module[{v, e, pos, graph}
+, v = stateVertexList @ state
+
+; e = stateEdgeList @ state
+
+; pos = If[
+    state[ "KeepVertexCoordinates"]
+  , stateGraphEmbedding @ state
+  , Automatic
+  ]
+
+; graph = Graph[ v, e, VertexCoordinates -> pos]
+
+; If[
+    TrueQ @ state[ "IndexGraph"]
+  , graph = IndexGraph @ graph
+  ]
+
+; graph
+]
+
+
+(* ::Subsubsection::Closed:: *)
+(*to state*)
+
+
+standardizeOption[VertexLabels][val_] := Replace[val, Automatic -> "Name"]
+standardizeOption[_][val_] := val
+
+
+GraphToEditorState[ opt:OptionsPattern[] ]:=GraphToEditorState @ Association[ Options @ IGGraphEditor, opt ]
+
+GraphToEditorState[ opts_Association ] := Module[{state}
+, state = <|
+      "vertex"         -> <||>
+    , "edge"           -> <||>
+    , "selectedVertex" -> Null
+    , "version"        -> $stateVersion
+    , optionsToConfig[opts]
+    , "vCounter"->0
+    , "eCounter" ->0
+    , "range" -> {{-1, 1}, {-1, 1}}
+    , "aspectRatio" -> 1
+    , "inRangeQ" -> RegionMember[ Rectangle[{-1,-1}, {1, 1}]  ]
+  |>
+
+; state = stateSnapInit @ state
+; state
+]
+
+
+
+optionsToConfig[options_Association] := KeyMap[ToString] @ options
+
+
+
+GraphToEditorState[g_Graph ? supportedGraphQ, opt:OptionsPattern[]] := Module[
+  {state, v, e, pos }
+, v = VertexList[g]
+; pos = GraphEmbedding @ g
+; e = EdgeList[g]
+
+; state = GraphToEditorState[<| Options @ IGGraphEditor, opt |>]
+
+; state["vertex"] = Association @ Map[ (#id -> #) & ] @ MapThread[createVertex, {v, pos}]
+
+; state["edge"]   = toStateEdges[state, g]
+
+; state[ "vCounter"] = Length@v
+; state[ "eCounter"] = Length@e
+; state[ "DirectedEdges"] = Not @ UndirectedGraphQ @ g
+
+; geAction["UpdateRange", Dynamic @ state]
+
+
+; state
+]
+
+
+(* ::Subsubsection:: *)
+(*state helpers*)
+
+
+stateSnapInit[state_Association] := Module[{newState = state }
+
+, newState["snap"] = newState["SnapToGrid"] =!= False
+
+; If[
+    newState["snap"]
+  , newState["snapStep"] = stateGetAutomaticSnapStep @ newState
+  ; newState["vertex"] = <|#, "pos" -> Round[#pos, newState["snapStep"]] |>& /@ newState["vertex"]
+  ]
+
+; newState
+]
+
+
+stateGetAutomaticSnapStep[state_Association] :=
+  Ceiling[#, .5]*10^#2 & @@ MantissaExponent[(#2 - #)/ $gridLinesCount] & @@@ state["range"]
+
+
+stateHandleNarrowRange[state_Association] := Module[
+  {range = state[ "range"], lengths, aspectRatio, center, side, newState}
+
+, lengths = #2-#& @@@ state[ "range"]
+; aspectRatio = #2/# & @@ Sort @ Clip[lengths, {10.^(-15), Infinity}]
+
+; If[ aspectRatio < $narrowAspectRatioLimit
+  , Return[state, Module]
+  ]
+
+; center = Mean @ Transpose @ range
+; side = Max @ lengths / 2.
+; range = Transpose[{{-1,-1},{1,1}}*side+{center,center}]
+
+; newState = state
+; newState[ "range"] = range
+; newState
+]
+
+
+toStateEdges[state_Association, graph_] := Module[{ }
+, edges = EdgeList @ graph
+; vertexRules = (#name -> #id) & /@ Values @ state["vertex"]
+; edges = Replace[edges, vertexRules , {2}]
+; Association @ Map[ (#id -> #) & ] @ MapIndexed[createEdge["e"<>ToString@First@#2, #]&, edges]
+
+]
+
+
+stateVertexList[state_Association] := Values @ state[["vertex", All, "name"]]
+
+
+stateEdgeList[state_Association] := state //
+ Query["edge", Values, ((#type /. # /. state[["vertex", All, "name"]])) &]
+
+
+stateGraphEmbedding[state_Association] := state // Query["vertex", Values, "pos"]
+
+
+stateHasSelectedVertex[state_Association] := StringQ @ state["selectedVertex"]
+
+
+stateHasCurvedEdges[state_Association]:= state[ "DirectedEdges"] 
+(*TODO: obviously this needs to be more precise, this is a first approximation, at least until we support multigraphs*)
+
+
 (* ::Subsection:: *)
 (*graphics*)
 
 
+(* ::Subsubsection::Closed:: *)
+(*geGraphics*)
+
+
 geGraphics[Dynamic @ state_ ] := DynamicModule[
-  {range = state["config", "range"], size = state["config", "ImageSize"], graphicsSize}
+  {range = state[ "range"], size = state["ImageSize"], graphicsSize}
 , Deploy @ EventHandler[
     Pane[
       DynamicWrapper[
@@ -162,23 +369,23 @@ geGraphics[Dynamic @ state_ ] := DynamicModule[
           DynamicNamespace @ {
             geHighlightsPrimitives @ Dynamic @ state
           , Gray
-          , Dynamic @ geEdges @ Dynamic @ state
-          , Dynamic @ geVertices @ Dynamic @ state
+          , geEdges @ Dynamic @ state
+          , geVertices @ Dynamic @ state
           }
         , PlotRange -> Dynamic @ range
         , ImageSize -> Dynamic @ graphicsSize 
         ]
-      , range = state["config", "range"]
-      ; graphicsSize = size = state["config", "ImageSize"]
+      , range = state[ "range"]
+      ; graphicsSize = size = state["ImageSize"]
       , TrackedSymbols :> {state}
       ]
     , AppearanceElements -> {"ResizeArea"}  
     , ImageSize -> Dynamic[
         size
-      , (size = {1, 1/state["config", "aspectRatio"]} * #[[1]] )&
+      , (size = {1, 1/state["aspectRatio"]} * #[[1]] )&
       ]
     ]
-  , "MouseUp" :> (state["config", "ImageSize"] = size)
+  , "MouseUp" :> (state["ImageSize"] = size)
   , PassEventsDown -> True
   ]
 
@@ -187,13 +394,16 @@ geGraphics[Dynamic @ state_ ] := DynamicModule[
    *)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*vertex*)
 
 
-geVertices[Dynamic @ state_] := Table[
-  geVertexShapeFunction[Dynamic@state, state["vertex", id] ]
-, {id, Keys @ state["vertex"] }
+geVertices[Dynamic @ state_] := PDynamic[
+dynamicLog["vertices"];
+Table[
+  geVertexShapeFunction[Dynamic@state, state[["vertex", pos ]]  ]
+, {pos, state["vCounter"] }
+]
 ]
 
 
@@ -201,7 +411,7 @@ geVertexShapeFunction[Dynamic @ state_, v_Association] :=
 With[ {
   nef = $vertexEdgeThickness
 , aef = $hoverVertexEdgeThickness
-, step = state["config", "snapStep"]
+, step = state["snapStep"]
 },
 DynamicModule[
   {x = v@"pos"},
@@ -211,18 +421,18 @@ Module[
 , graphics = { {
     EdgeForm @ AbsoluteThickness @  Dynamic[ FEPrivate`If[  FrontEnd`CurrentValue["MouseOver"], aef, nef ] ]
   , DynamicName[
-      Disk[Dynamic[x], state["config", "realVertexSize"]]
+      Disk[Dynamic[x], state["realVertexSize"]]
     , v["id"]
     ]
   }
   , If[
-      state["config", "VertexLabels"] === "Name"
+      state["VertexLabels"] === "Name"
     , Inset[v["name"], Offset[ {12, 12}, DynamicLocation[v["id"]]] ]
     , Nothing
     ]
   }
 
-; mouseDragged = If[ state["config", "snap"]
+; mouseDragged = If[ state[ "snap"]
     , "MouseDragged" :> (x = Round[CurrentValue[{"MousePosition", "Graphics"}], step])
     , "MouseDragged" :> FEPrivate`Set[x , FrontEnd`CurrentValue[{"MousePosition", "Graphics"}] ]
   ]
@@ -244,8 +454,12 @@ Module[
 (*edges*)
 
 
-geEdges[Dynamic @ state_] := Table[
-  geEdgeShapeFunction[ Dynamic@state,  state["edge", id]], {id, Keys @ state["edge"]}
+geEdges[Dynamic @ state_] := PDynamic[
+dynamicLog["edges"];
+Table[
+  geEdgeShapeFunction[ Dynamic@state,  state[["edge"]][[ pos ]] ]
+, {pos, state["eCounter"]}
+]
 ]
 
 
@@ -287,13 +501,14 @@ edgeTypeToPrimitive[UndirectedEdge["v1", "v2"]] = Line[{#,#2}]&
 
 geHighlightsPrimitives[Dynamic @ state_] := With[{ selV := state["selectedVertex"] }
 , { $potentialEdgeStyle,
-    Dynamic[
+    PDynamic[
+      dynamicLog["selection"];
       If[
         stateHasSelectedVertex @ state
       , {  
           EdgeForm @ DeleteCases[$potentialEdgeStyle, _Dashing]
         , EdgeForm @ AbsoluteThickness[ 3 * $hoverVertexEdgeThickness ]
-        , Disk[DynamicLocation[selV], state["config", "realVertexSize"]]
+        , Disk[DynamicLocation[selV], state[ "realVertexSize"]]
         , Line[{
             DynamicLocation[selV]
           , FrontEnd`MousePosition["Graphics",DynamicLocation[selV]]
@@ -307,183 +522,11 @@ geHighlightsPrimitives[Dynamic @ state_] := With[{ selV := state["selectedVertex
 ]
 
 
-(* ::Subsection::Closed:: *)
-(*state version*)
-
-
-$stateVersion = 1;
-(*It does not change unless the structure of state association is changed.
-  That implies new geActions etc won't be compatible with old state *)
-
-
-(*ONCE $stateVersion > 1 *)
-(*
-  geStateVersionCheck[ state : KeyValuePattern[{"version" \[Rule] oldVersion}] ] := (*oldVersion to oldVersion+1 transition rules*)
-*)
-
-
-geStateVersionCheck[ state : KeyValuePattern[{"version" -> $stateVersion}] ] := state
-
-
-geStateVersionCheck[ state : KeyValuePattern[{"version" -> v_}] ] :=
-  Failure["GraphEditor", <|"MessageTemplate" -> IGGraphEditor::oldVer|>]
-
-
-geStateVersionCheck[___] :=
-  Failure["GraphEditor", <|"MessageTemplate" -> IGGraphEditor::unknownState|>]
-
-
-(* ::Subsection::Closed:: *)
-(*from state*)
-
-
-GraphFromEditorState[state_Association] := GraphFromEditorState[state, Lookup[state, "version", 1]];
-
-
-GraphFromEditorState[state_, 1] := Module[{v, e, pos, graph}
-, v = stateVertexList @ state
-
-; e = stateEdgeList @ state
-
-; pos = If[
-    state["config", "KeepVertexCoordinates"]
-  , stateGraphEmbedding @ state
-  , Automatic
-  ]
-
-; graph = Graph[ v, e, VertexCoordinates -> pos]
-
-; If[
-    TrueQ @ state["config", "IndexGraph"]
-  , graph = IndexGraph @ graph
-  ]
-
-; graph
-]
-
-
-(* ::Subsection:: *)
-(*to state*)
-
-standardizeOption[VertexLabels][val_] := Replace[val, Automatic -> "Name"]
-standardizeOption[_][val_] := val
-
-
-GraphToEditorState[ opt:OptionsPattern[] ]:=GraphToEditorState @ Association[ Options @ IGGraphEditor, opt ]
-
-GraphToEditorState[ opts_Association ] := Module[{state}
-, state = <|
-      "vertex"         -> <||>
-    , "edge"           -> <||>
-    , "selectedVertex" -> Null
-    , "version"        -> $stateVersion
-    , "config"         -> <|
-        optionsToConfig[opts]
-      , "vCounter"->0
-      , "eCounter" ->0
-      , "range" -> {{-1, 1}, {-1, 1}}
-      , "aspectRatio" -> 1
-      , "inRangeQ" -> RegionMember[ Rectangle[{-1,-1}, {1, 1}]  ]
-      |>
-    |>
-
-; state = stateSnapInit @ state
-; state
-]
-
-
-
-optionsToConfig[options_Association] := KeyMap[ToString] @ options
-
-
-
-GraphToEditorState[g_Graph ? supportedGraphQ, opt:OptionsPattern[]] := Module[
-  {state, v, e, pos }
-, v = VertexList[g]
-; pos = GraphEmbedding @ g
-; e = EdgeList[g]
-
-; state = GraphToEditorState[<| Options @ IGGraphEditor, opt |>]
-
-; state["vertex"] = Association @ Map[ (#id -> #) & ] @ MapThread[createVertex, {v, pos}]
-
-; state["edge"]   = toStateEdges[state, g]
-
-; state[ "config", "vCounter"] = Length@v
-; state[ "config", "eCounter"] = Length@e
-; state[ "config", "DirectedEdges"] = Not @ UndirectedGraphQ @ g
-
-; geAction["UpdateRange", Dynamic @ state]
-
-
-; state
-]
-
-
-(* ::Subsection::Closed:: *)
-(*state helpers*)
-
-stateSnapInit[state_Association] := Module[{config = state["config"], result = state }
-
-, config["snap"] = config["SnapToGrid"] =!= False
-
-; If[
-    config["snap"]
-  , config["snapStep"] = stateGetAutomaticSnapStep @ state
-  ; result["vertex"] = <|#, "pos" -> Round[#pos, config["snapStep"]] |>& /@ state["vertex"]
-  ]
-
-; <|result, "config" -> config |>
-]
-
-
-stateGetAutomaticSnapStep[state_Association] :=
-  Ceiling[#, .5]*10^#2 & @@ MantissaExponent[(#2 - #)/ $gridLinesCount] & @@@ state["config", "range"]
-
-
-stateHandleNarrowRange[state_Association] := Module[
-  {range = state["config", "range"], lengths, aspectRatio, center, side, newState}
-
-, lengths = #2-#& @@@ state["config", "range"]
-; aspectRatio = #2/# & @@ Sort @ Clip[lengths, {10.^(-15), Infinity}]
-
-; If[ aspectRatio < $narrowAspectRatioLimit
-  , Return[state, Module]
-  ]
-
-; center = Mean @ Transpose @ range
-; side = Max @ lengths / 2.
-; range = Transpose[{{-1,-1},{1,1}}*side+{center,center}]
-
-; newState = state
-; newState[ "config", "range"] = range
-; newState
-]
-
-
-toStateEdges[state_Association, graph_] := Module[{ }
-, edges = EdgeList @ graph
-; vertexRules = (#name -> #id) & /@ Values @ state["vertex"]
-; edges = Replace[edges, vertexRules , {2}]
-; Association @ Map[ (#id -> #) & ] @ MapIndexed[createEdge["e"<>ToString@First@#2, #]&, edges]
-
-]
-
-stateVertexList[state_Association] := Values @ state[["vertex", All, "name"]]
-
-stateEdgeList[state_Association] := state //
- Query["edge", Values, ((#type /. # /. state[["vertex", All, "name"]])) &]
-
-stateGraphEmbedding[state_Association] := state // Query["vertex", Values, "pos"]
-
-stateHasSelectedVertex[state_Association] := StringQ @ state["selectedVertex"]
-
-
 (* ::Subsection:: *)
 (*UI Actions*)
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*$geDebug*)
 
 
@@ -492,43 +535,58 @@ stateHasSelectedVertex[state_Association] := StringQ @ state["selectedVertex"]
 $actionLevel = -1;
 
 If[
+  TrueQ @ $logDynamic
+, dynamicLog[msg_]:=Print[Style[Row[{"Updating :", msg}],Red]]
+]
+
+If[
   TrueQ @ $geDebug
 
 , geAction[args___] := (Beep[]; Print @ Framed @ InputForm @ {args})
+
 ; Module[{$inside = False}
   , geAction /: SetDelayed[geAction[args___], rhs_] /; !TrueQ[$inside] := Block[
       {$inside = True}
-    , geAction[a:PatternSequence[args]]:=Internal`InheritedBlock[{ $actionLevel = $actionLevel + 1},
-        Print[          
-          Style[
-            StringPadRight[
-              StringJoin @ ConstantArray["- ", $actionLevel] <> {a}[[1]]
-            , 24]
-          , Bold]
-        , ":", {a}[[3;;]]
-        ]
-      ; rhs
+    , geAction[a:PatternSequence[args]]:=Internal`InheritedBlock[{ $actionLevel = $actionLevel + 1}
+      , Module[{result, start = AbsoluteTime[]}
+        , logAction[a]
+        ; result = rhs
+        ; Print[StringJoin@ConstantArray["  ", $actionLevel], "timing: ", AbsoluteTime[] - start, "[s]"]
+        ; result  
+        ]      
       ]
     ]
   ]
 ]
 
+logAction[head_, state_, args___]:= With[
+  { indent = StringJoin @ ConstantArray["- ", $actionLevel] } 
+, Print[          
+    Row[{ 
+      indent
+    , Style[head, Bold]
+    , ":"
+    , args
+    }, BaseStyle->LineBreakWithin->False]
+  ]
+]
 
-(* ::Subsubsection:: *)
+
+(* ::Subsubsection::Closed:: *)
 (*UpdateVertexPosition*)
 
 
 geAction["UpdateVertexPosition", Dynamic @ state_, vId_String, pos: {_, _}] := (
   state["vertex", vId, "pos"] = pos
 ; If[
-    ! state["config", "inRangeQ"] @ pos
+    ! state["inRangeQ"] @ pos
   , geAction["UpdateRange", Dynamic @ state]
   ]
 ; geAction["UpdateEdgesShapes", Dynamic @ state]
 )
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*UpdateRange*)
 
 
@@ -538,16 +596,16 @@ geAction["UpdateRange", Dynamic @ state_] := Module[
 , embedding = state // Query["vertex", All, "pos"]
 ; If[ Length[embedding ] < 1, Return[False, Module]]
 
-; vs = vertexSizeMultiplier @ state["config", "VertexSize"]
+; vs = vertexSizeMultiplier @ state[ "VertexSize"]
 ; newBounds = handleDegeneratedRange @ CoordinateBounds[ embedding, Scaled[ 2.5 Max[vs, 0.05 ] ] ]
 
 
-; state[ "config", "range"] = newBounds
+; state[ "range"] = newBounds
 ; state = stateHandleNarrowRange @ state
 
-; state[ "config", "aspectRatio"] = #/#2& @@ (#2-#& @@@ state[ "config", "range"])
-; state[ "config", "ImageSize" ] = {1, 1/state[ "config", "aspectRatio"]} * If[ListQ@#, First@#,#]& @ state[ "config", "ImageSize"]
-; state[ "config", "inRangeQ" ] = RegionMember[ Rectangle @@ Transpose@ state[ "config", "range"] ]
+; state[  "aspectRatio"] = #/#2& @@ (#2-#& @@@ state[ "range"])
+; state[  "ImageSize" ] = {1, 1/state[  "aspectRatio"]} * If[ListQ@#, First@#,#]& @ state[ "ImageSize"]
+; state[  "inRangeQ" ] = RegionMember[ Rectangle @@ Transpose@ state[  "range"] ]
 ; geAction["UpdateVertexSize", Dynamic @ state]
 ]
 
@@ -568,10 +626,10 @@ handleDegeneratedRange[range : {{xmin_, xmax_}, {ymin_, ymax_}}] := Module[{}
 
 
 geAction["UpdateVertexSize", _ @ state_ ] := With[{ (* _ @ for interpretation bug fix *)
-  boundingBox = Transpose @ state[ "config", "range"]
-, sizeMultiplier = vertexSizeMultiplier @ state["config", "VertexSize"]
+  boundingBox = Transpose @ state[ "range"]
+, sizeMultiplier = vertexSizeMultiplier @ state[ "VertexSize"]
 }
-, state[ "config", "realVertexSize" ] = Norm[ boundingBox ] * sizeMultiplier
+, state[  "realVertexSize" ] = Norm[ boundingBox ] * sizeMultiplier
 
 ]
 
@@ -582,6 +640,8 @@ vertexSizeMultiplier[vs_] := vs /. {
   Medium -> 0.05,
   Large -> 0.15
 } /. Except[_?NumericQ] -> 0.05
+
+
 (* ::Subsubsection::Closed:: *)
 (*MouseClicked*)
 
@@ -656,15 +716,15 @@ geAction["Unselect", Dynamic @ state_] := state["selectedVertex"] = Null
 
 geAction["AddVertex", Dynamic @ state_, pos:{_?NumericQ, _?NumericQ}] := Module[{vertex, name}
 
-, state["config", "vCounter"]++
+, state[ "vCounter"]++
 
 ; name = Check[generateUniqueVertexName @ state, CreateUUID[]]
 
 ; vertex = createVertex[name, pos]
 ; id = vertex["id"]
 
-; If[ state["config", "snap"]
-  , newV["pos"] = MapThread[Round, {vertex["pos"], state["config", "snapStep"]} ]
+; If[ state["snap"]
+  , newV["pos"] = MapThread[Round, {vertex["pos"], state[ "snapStep"]} ]
   ]
 
 ; state["vertex", id ] = vertex
@@ -675,7 +735,7 @@ geAction["AddVertex", Dynamic @ state_, pos:{_?NumericQ, _?NumericQ}] := Module[
   ]
 
 ; If[
-    state["config", "CreateVertexSelects"]
+    state[ "CreateVertexSelects"]
   , geAction["Select", Dynamic @ state, id]
   ]
 
@@ -706,6 +766,8 @@ smallestMissingInteger[list_List] := Block[{n = 1}
 geAction["RemoveVertex", Dynamic @ state_, v_] := With[{ id = v["id"]}
 , state["vertex"]  = KeyDrop[id] @ state["vertex"]
 ; state["edge"]    = DeleteCases[state["edge"], KeyValuePattern[{_ -> id}] ]
+; state["vCounter"]--
+; state["eCounter"] = Length @ state["edge"]
 ; If[ state["selectedVertex"] === id, geAction["Unselect", Dynamic @ state] ]
 ]
 
@@ -722,8 +784,8 @@ geAction["CreateEdge", Dynamic @ state_, selectedV_String, clickedV_String] := M
   ; Return[$Failed, Module]
   ]
 
-; eId = "e"<>ToString[++state["config", "eCounter"]]
-; type =   If[state["config", "DirectedEdges"], Rule, UndirectedEdge]
+; eId = "e"<>ToString[++state[ "eCounter"]]
+; type =   If[state["DirectedEdges"], Rule, UndirectedEdge]
 
 ; state["edge", eId ] = createEdge[eId,  type[selectedV, clickedV] ]
 
@@ -740,6 +802,7 @@ geAction["CreateEdge", Dynamic @ state_, selectedV_String, clickedV_String] := M
 geAction["RemoveEdge", Dynamic @ state_, edge_Association] := (
   state["edge"] = KeyDrop[edge["id"]] @ state["edge"]
 ; geAction["UpdateEdgesShapes", Dynamic @ state]
+; state["eCounter"]--  
 )
 
 
@@ -761,7 +824,9 @@ geAction["ToggleEdgeType", Dynamic@state_, edge_] := With[{ type := state["edge"
 
 geAction["UpdateEdgesShapes", _ @ state_] := Module[{primitives,  vertexEncoded, vertexList}
 
-, primitives = extractEdgePrimitives @ state
+, If[ ! stateHasCurvedEdges @ state, Return[False, Module]]
+
+; primitives = extractEdgePrimitives @ state
 
 ; vertexList = state // Query["vertex", Values, "id"]
 ; vertexEncoded = AssociationThread[
@@ -770,6 +835,7 @@ geAction["UpdateEdgesShapes", _ @ state_] := Module[{primitives,  vertexEncoded,
 
 ; ( state["edge", #id, "shape"] = ToEdgeShapeFunction[#primitive, vertexEncoded] )& /@ primitives
 ]
+
 
 extractEdgePrimitives[state_] := Module[{graph, vertexList, edgeList, embedding}
 
@@ -818,7 +884,7 @@ newEdgeAllowedQ::usage = "Is supposed to test whether a new edge can be created"
 newEdgeAllowedQ[state_, v1_String, v2_String] := Module[{edges}
 , edges = Values @ state["edge"]
 ; If[
-    state["config", "DirectedEdges"]
+    state["DirectedEdges"]
   , Not @ MemberQ[ edges , KeyValuePattern[{"v1" -> v1, "v2" -> v2, "type" -> ("v1"->"v2")}] ]
   , Not @ MemberQ[ edges , KeyValuePattern[{ _   -> v1,  _   -> v2, "type" -> _UndirectedEdge}] ]
   ]

--- a/IGraphM/GraphEditor.m
+++ b/IGraphM/GraphEditor.m
@@ -472,10 +472,15 @@ geEdgeShapeFunction[Dynamic @ state_, e_Association] := EventHandler[
   ]
 
 
-edgeHoverWrapper[primitive_]:=  {
-  AbsoluteThickness @  Dynamic[ FEPrivate`If[  FrontEnd`CurrentValue["MouseOver"], $activeEdgeThickness, $edgeThickness ] ]
+edgeHoverWrapper[primitive_]:=  With[
+  {
+    nef = $edgeThickness,
+    aef = $activeEdgeThickness
+  },{
+  AbsoluteThickness @  Dynamic[ FEPrivate`If[  FrontEnd`CurrentValue["MouseOver"], aef, nef ] ]
 , primitive
 }
+]
 
 
 If[ $VersionNumber > 12

--- a/IGraphM/GraphEditor.m
+++ b/IGraphM/GraphEditor.m
@@ -437,8 +437,8 @@ Module[
 
 ; EventHandler[
     graphics,
-    { "MouseClicked" :> (TaskRemove @ task; geAction["VertexClicked", Dynamic @ state, v] )
-    , "MouseUp"      :> (task = SessionSubmit @ ScheduledTask[ geAction["UpdateVertexPosition", Dynamic @ state, v["id"], x] , {0.1}])
+    { "MouseClicked" :> (RemoveScheduledTask @ task; geAction["VertexClicked", Dynamic @ state, v] )
+    , "MouseUp"      :> (task = RunScheduledTask[ geAction["UpdateVertexPosition", Dynamic @ state, v["id"], x] , {0.1}])
     , If[ state[ "snap"]
       , "MouseDragged" :> (x = Round[CurrentValue[{"MousePosition", "Graphics"}], step])
       , "MouseDragged" :> FEPrivate`Set[x , FrontEnd`CurrentValue[{"MousePosition", "Graphics"}] ]

--- a/IGraphM/GraphEditor.m
+++ b/IGraphM/GraphEditor.m
@@ -558,7 +558,7 @@ If[
       , Module[{result, start = AbsoluteTime[]}
         , logAction[a]
         ; result = rhs
-        ; Print[StringJoin@ConstantArray["  ", $actionLevel], "timing: ", AbsoluteTime[] - start, "[s]"]
+        ; If[$logTimings, Print[StringJoin@ConstantArray["  ", $actionLevel], "timing: ", AbsoluteTime[] - start, "[s]"]]
         ; result  
         ]      
       ]

--- a/IGraphM/PreciseTracking.m
+++ b/IGraphM/PreciseTracking.m
@@ -1,0 +1,89 @@
+(* Mathematica Package *)
+
+(* :Title: PreciseTracking *)
+(* :Context: PreciseTracking` *)
+(* :Author: Kuba Podkalicki (kuba.pod@gmail.com) *)
+(* :Date: Mon 17 Jun 2019 00:55:33 *)
+
+(* :Keywords: *)
+(* :Discussion: *)
+
+
+
+Package["IGraphM`"]
+
+
+PackageScope["ToTrackedAssociation"]
+PackageScope["StopTracking"]
+PackageScope["PreciseDynamic"]  (*obsolete*)
+PackageScope["PDynamic"]
+
+
+  If[ Not @ TrueQ @ AssociationQ @ $TrackedTargets
+    , $TrackedTargets = <||>     
+  ];
+
+  TrackTarget // Attributes = {HoldAll, Listable};
+
+  TrackTarget[sym_[key_]]:= Catch @ With[
+    { id   = First @ ValueTrack`GetTrackingState[]
+    , bin := $TrackedTargets
+    , root = Hold[sym]
+    }
+  , Lookup[bin, root, bin[root]=<|key -> {id}|>; Throw @ {id} ] (*initialize storage if needed*)
+  ; If[
+      FreeQ[id] @ Lookup[bin[root], key, bin[root, key] = {}]
+    , AppendTo[bin[root, key], id]
+    ]
+  
+  ]
+
+  UpdateTarget // Attributes = HoldAll;
+
+  UpdateTarget[sym_[key_]]:= With[
+    { root = Hold[sym]
+    , bin := $TrackedTargets
+    }
+  , { ids = Lookup[bin[root], key, {}] /. {} :> Return[Null, With]}
+
+  , bin[root, key] = {}  
+  ; CallPacket @ FrontEndExecute @ FrontEnd`UpdateDynamicObjects @ ids
+  ]
+
+
+  PreciseDynamic // Attributes = HoldAll;
+
+  PreciseDynamic[expr_, target_]:= Dynamic[TrackTarget[target]; expr, TrackedSymbols:>{}];
+
+  PreciseDynamic[sym_[key_]]:= PreciseDynamic[sym[key],sym[key]]
+
+
+PDynamic // Attributes = HoldAll;
+PDynamic[expr_]:=Dynamic[EvaluatePDynamic[expr], TrackedSymbols:>{}]
+
+EvaluatePDynamic // Attributes = HoldAll;
+EvaluatePDynamic[expr_]:=With[
+  { trackedAssociation = Alternatives @@ HoldPattern @@@ Keys @ $TrackedTargets}
+, Cases[Hold[expr], o:(trackedAssociation[spec_String]) :> TrackTarget[o], \[Infinity] ]
+; expr
+]
+
+  ToTrackedAssociation // Attributes = {HoldFirst};
+
+  ToTrackedAssociation[sym_Symbol]:=Module[
+    {   $inside = False }
+    , If[! KeyExistsQ[Hold[sym]]@$TrackedTargets, $TrackedTargets[ Hold[sym] ] = <||> ]
+    ; sym /: Set[sym[key_, rest___], val_] /; !TrueQ@$inside :=Block[
+      {$inside = True, $old = sym[key, rest]}
+      , sym[key, rest]=val            
+      ; If[ $old =!= val      
+        , UpdateTarget[sym[key]] ]
+      ; val
+    ]
+  ]
+
+  StopTracking // Attributes = {HoldFirst}
+
+  StopTracking[sym_Symbol]:= KeyDropFrom[$TrackedTargets, Hold[sym] ]
+
+  

--- a/Tests/Editor interactive tests.wl
+++ b/Tests/Editor interactive tests.wl
@@ -27,7 +27,7 @@ IGraphM`GraphEditor`PackagePrivate`$gridLinesCount=25.;
 TestReport@FileNameJoin[{NotebookDirectory[], "Editor.wl"}]
 
 
-SetOptions[IGGraphEditor, ImageSize->200];
+SetOptions[IGGraphEditor, ImageSize->Automatic];
 
 
 (* ::Subsection:: *)
@@ -51,9 +51,6 @@ SetOptions[IGGraphEditor, ImageSize->200];
 IGGraphEditor[Graph@{1->2,2->1},VertexSize->Small, "DirectedEdges"->True]
 
 
-\[AliasDelimiter]
-
-
 IGraphM`PreciseTracking`PackagePrivate`$TrackedTargets
 
 
@@ -75,6 +72,9 @@ IGGraphEditor[ImageSize->100]
 
 (* ::Text:: *)
 (*Try to edit them*)
+
+
+IGGraphEditor[CompleteGraph[2, DirectedEdges -> True]]
 
 
 { IGGraphEditor[IGEmptyGraph[]],

--- a/Tests/Editor interactive tests.wl
+++ b/Tests/Editor interactive tests.wl
@@ -17,7 +17,8 @@ SetSelectedNotebook@MessagesNotebook[];
 SetSelectedNotebook@EvaluationNotebook[];
 FrontEndExecute[FrontEndToken["DeleteGeneratedCells"]]
 
-IGraphM`GraphEditor`PackagePrivate`$geDebug=False;
+IGraphM`GraphEditor`PackagePrivate`$geDebug=True;
+IGraphM`GraphEditor`PackagePrivate`$logTimings=False;
 IGraphM`GraphEditor`PackagePrivate`$logDynamic=True;
 Get["IGraphM`"]
 IGraphM`GraphEditor`PackagePrivate`$gridLinesCount=25.;
@@ -44,9 +45,13 @@ SetOptions[IGGraphEditor, ImageSize->200];
 (*- Alt+click should not trigger orange resize frame, nor should discarding a potential edge.*)
 (*- Click on vertex should not trigger update vertex position*)
 (*- Hover over edge/vertex should thicken it.*)
+(*- Are curved edges redrawn @mouseUp?*)
 
 
-IGGraphEditor[VertexSize->Small, "SnapToGrid"->True]
+IGGraphEditor[Graph@{1->2,2->1},VertexSize->Small, "DirectedEdges"->True]
+
+
+\[AliasDelimiter]
 
 
 IGraphM`PreciseTracking`PackagePrivate`$TrackedTargets

--- a/Tests/Editor interactive tests.wl
+++ b/Tests/Editor interactive tests.wl
@@ -17,7 +17,8 @@ SetSelectedNotebook@MessagesNotebook[];
 SetSelectedNotebook@EvaluationNotebook[];
 FrontEndExecute[FrontEndToken["DeleteGeneratedCells"]]
 
-IGraphM`GraphEditor`PackagePrivate`$geDebug=True;
+IGraphM`GraphEditor`PackagePrivate`$geDebug=False;
+IGraphM`GraphEditor`PackagePrivate`$logDynamic=True;
 Get["IGraphM`"]
 IGraphM`GraphEditor`PackagePrivate`$gridLinesCount=25.;
 
@@ -26,6 +27,10 @@ TestReport@FileNameJoin[{NotebookDirectory[], "Editor.wl"}]
 
 
 SetOptions[IGGraphEditor, ImageSize->200];
+
+
+(* ::Subsection:: *)
+(*hands on tests*)
 
 
 (* ::Subsubsection:: *)
@@ -40,6 +45,32 @@ SetOptions[IGGraphEditor, ImageSize->200];
 
 
 IGGraphEditor[VertexSize->Small]
+
+
+(* ::Input:: *)
+(*\!\( *)
+(*TagBox[*)
+(*DynamicModuleBox[{IGraphM`GraphEditor`PackagePrivate`state$$ = <|"vertex" -> <|"4f62303b-bf36-48ec-9ed3-79d7d141e6c5" -> <|"name" -> 1, "id" -> "4f62303b-bf36-48ec-9ed3-79d7d141e6c5", "pos" -> {-0.5349999999999999, 0.3918525382413843}|>, "39d3f441-bbfe-4cfe-8c6b-04f4e193bb67" -> <|"name" -> 4, "id" -> "39d3f441-bbfe-4cfe-8c6b-04f4e193bb67", "pos" -> {0.45500000000000007`, -0.34314746175861577`}|>, "bdbcd0d0-01d5-46b2-a071-3c742217ee58" -> <|"name" -> 6, "id" -> "bdbcd0d0-01d5-46b2-a071-3c742217ee58", "pos" -> {0.18000000000000016`, -0.5931474617586158}|>, "45c84633-138c-433b-bb0d-2475b7fdb6f8" -> <|"name" -> 2, "id" -> "45c84633-138c-433b-bb0d-2475b7fdb6f8", "pos" -> {0.09499999999999997, 0.4968525382413843}|>, "046655c3-593a-446e-a681-2e2d5ba7ef9d" -> <|"name" -> 5, "id" -> "046655c3-593a-446e-a681-2e2d5ba7ef9d", "pos" -> {1.665, 0.23185253824138424`}|>, "dd43662b-914b-47e0-94ab-a38c924f28ae" -> <|"name" -> 7, "id" -> "dd43662b-914b-47e0-94ab-a38c924f28ae", "pos" -> {-0.2699999999999999, 0.44685253824138427`}|>|>, "edge" -> <|"e3" -> <|"v1" -> "046655c3-593a-446e-a681-2e2d5ba7ef9d", "v2" -> "dd43662b-914b-47e0-94ab-a38c924f28ae", "id" -> "e3", "type" -> UndirectedEdge["v1", "v2"], "shape" -> Automatic|>|>, "selectedVertex" -> Null, "version" -> 2, "KeepVertexCoordinates" -> True, "CreateVertexSelects" -> True, "SnapToGrid" -> False, "IndexGraph" -> False, "PerformanceLimit" -> 450, "VertexLabels" -> None, "VertexSize" -> Small, "DirectedEdges" -> False, "ImageSize" -> {300, 148.63636363636365`}, "vCounter" -> 6, "eCounter" -> 1, "range" -> {{-0.8099999999999999, 1.94}, {-0.7293974617586158, 0.6331025382413843}}, "aspectRatio" -> 2.018348623853211, "inRangeQ" -> RegionMemberFunction[MeshRegion[{{-0.8099999999999999, -0.7293974617586158}, {1.94, -0.7293974617586158}, {1.94, 0.6331025382413843}, {-0.8099999999999999, 0.6331025382413843}}, {Polygon[{{1, 2, 3, 4}}]}, Method -> {"EliminateUnusedCoordinates" -> True, "DeleteDuplicateCoordinates" -> Automatic, "DeleteDuplicateCells" -> Automatic, "VertexAlias" -> Identity, "CheckOrientation" -> Automatic, "CoplanarityTolerance" -> Automatic, "CheckIntersections" -> Automatic, "BoundaryNesting" -> Automatic, "SeparateBoundaries" -> Automatic, "TJunction" -> Automatic, "PropagateMarkers" -> True, "ZeroTest" -> Automatic, "Hash" -> 6068137075315393170}], 2, Region`Mesh`CanonicalDistance[True]], "snap" -> False, "realVertexSize" -> 0.03419170071312608|>, IGraphM`GraphEditor`PackagePrivate`error$$ = False, IGraphM`GraphEditor`PackagePrivate`refresh$$}, *)
+(*InterpretationBox[*)
+(*PaneSelectorBox[{True->*)
+(*ButtonBox[*)
+(*DynamicBox[ToBoxes[IGraphM`GraphEditor`PackagePrivate`error$$, StandardForm]],*)
+(*Appearance->Automatic,*)
+(*BaseStyle->15,*)
+(*ButtonFunction:>IGraphM`GraphEditor`PackagePrivate`refresh$$[],*)
+(*Evaluator->Automatic,*)
+(*Method->"Preemptive"], False->*)
+(*PanelBox[*)
+(*DynamicBox[ToBoxes[Refresh[IGraphM`GraphEditor`PackagePrivate`iGraphEditorPanel[Dynamic[IGraphM`GraphEditor`PackagePrivate`state$$]], None], StandardForm],*)
+(*ImageSizeCache->{300., {72.25177550659812, 76.38458812976553}}],*)
+(*BaseStyle->(CacheGraphics -> False),*)
+(*FrameMargins->0]}, Dynamic[MatchQ[Blank[Failure]][IGraphM`GraphEditor`PackagePrivate`error$$]],*)
+(*ImageSize->Automatic],*)
+(*IGraphM`GraphEditor`PackagePrivate`GraphFromEditorState[IGraphM`GraphEditor`PackagePrivate`state$$]],*)
+(*Deinitialization:>IGraphM`GraphEditor`PackagePrivate`iGraphEditorDeinitialization[IGraphM`GraphEditor`PackagePrivate`state$$],*)
+(*DynamicModuleValues:>{{UpValues[IGraphM`GraphEditor`PackagePrivate`state$$] = {HoldPattern[Condition[IGraphM`GraphEditor`PackagePrivate`state$$[Pattern[IGraphM`PreciseTracking`PackagePrivate`key$, Blank[]], Pattern[IGraphM`PreciseTracking`PackagePrivate`rest$, BlankNullSequence[]]] = Pattern[IGraphM`PreciseTracking`PackagePrivate`val$, Blank[]], Not[TrueQ[IGraphM`PreciseTracking`PackagePrivate`$inside$7851]]]] :> Block[{IGraphM`PreciseTracking`PackagePrivate`$inside$7851 = True, IGraphM`PreciseTracking`PackagePrivate`$old = IGraphM`GraphEditor`PackagePrivate`state$$[IGraphM`PreciseTracking`PackagePrivate`key$, IGraphM`PreciseTracking`PackagePrivate`rest$]}, IGraphM`GraphEditor`PackagePrivate`state$$[IGraphM`PreciseTracking`PackagePrivate`key$, IGraphM`PreciseTracking`PackagePrivate`rest$] = IGraphM`PreciseTracking`PackagePrivate`val$; If[IGraphM`PreciseTracking`PackagePrivate`$old =!= IGraphM`PreciseTracking`PackagePrivate`val$, IGraphM`PreciseTracking`PackagePrivate`UpdateTarget[IGraphM`GraphEditor`PackagePrivate`state$$[IGraphM`PreciseTracking`PackagePrivate`key$]]]; IGraphM`PreciseTracking`PackagePrivate`val$]}}, {DownValues[IGraphM`GraphEditor`PackagePrivate`refresh$$] = {HoldPattern[IGraphM`GraphEditor`PackagePrivate`refresh$$[]] :> Module[{IGraphM`GraphEditor`PackagePrivate`temp$}, Catch[If[Needs["IGraphM`"] === $Failed, Throw[IGraphM`GraphEditor`PackagePrivate`error$$ = Failure["GraphEditor", <|"Message" -> "\[WarningSign] Failed to load IGraphM`, make sure it is installed."|>]]]; IGraphM`GraphEditor`PackagePrivate`temp$ = IGraphM`GraphEditor`PackagePrivate`geStateVersionCheck[IGraphM`GraphEditor`PackagePrivate`state$$]; If[AssociationQ[IGraphM`GraphEditor`PackagePrivate`temp$], IGraphM`GraphEditor`PackagePrivate`state$$ = IGraphM`GraphEditor`PackagePrivate`temp$, Throw[IGraphM`GraphEditor`PackagePrivate`error$$ = IGraphM`GraphEditor`PackagePrivate`temp$]]; IGraphM`GraphEditor`PackagePrivate`iGraphEditorInitialization[IGraphM`GraphEditor`PackagePrivate`state$$, IGraphM`GraphEditor`PackagePrivate`error$$]]]}}},*)
+(*Initialization:>IGraphM`GraphEditor`PackagePrivate`refresh$$[]],*)
+(*Setting[#, {0}]& ]\)*)
 
 
 IGGraphEditor[ImageSize->100]
@@ -100,3 +131,31 @@ IGGraphEditor[
 	VertexLabels -> "Name",
 	ImageSize -> 800
 ]
+
+
+(* ::Subsection:: *)
+(*Notebook*)
+
+
+IGGraphEditor[IGGraphAtlas[123]]
+
+
+g = IGLayoutTutte@IGEdgeMap[#^1.5&, EdgeWeight]@IGDistanceWeighted@IGLayoutTutte@Graph@EdgeList@GraphData["GreatRhombicosidodecahedralGraph"]
+
+
+IGGraphEditor[g]
+
+
+IGGraphEditor[GraphData["GreatRhombicosidodecahedralGraph"], VertexSize->Tiny,ImageSize->700, VertexLabels->"Name"]
+
+
+IGGraphEditor[Graph[{1->2,2->3,3->1}]]
+
+
+Graph[{1->2,2->1,3->1}]//SimpleGraphQ
+
+
+MultigraphQ
+
+
+PreciseTracking`Private`$TrackedTargets

--- a/Tests/Editor interactive tests.wl
+++ b/Tests/Editor interactive tests.wl
@@ -17,9 +17,9 @@ SetSelectedNotebook@MessagesNotebook[];
 SetSelectedNotebook@EvaluationNotebook[];
 FrontEndExecute[FrontEndToken["DeleteGeneratedCells"]]
 
-IGraphM`GraphEditor`PackagePrivate`$geDebug=True;
+IGraphM`GraphEditor`PackagePrivate`$geDebug=False;
 IGraphM`GraphEditor`PackagePrivate`$logTimings=False;
-IGraphM`GraphEditor`PackagePrivate`$logDynamic=True;
+IGraphM`GraphEditor`PackagePrivate`$logDynamic=False;
 Get["IGraphM`"]
 IGraphM`GraphEditor`PackagePrivate`$gridLinesCount=25.;
 

--- a/Tests/Editor interactive tests.wl
+++ b/Tests/Editor interactive tests.wl
@@ -42,35 +42,14 @@ SetOptions[IGGraphEditor, ImageSize->200];
 (*- Evaluate output to create a graph*)
 (*- Drag outside of range should extend the range @mouseUp*)
 (*- Alt+click should not trigger orange resize frame, nor should discarding a potential edge.*)
+(*- Click on vertex should not trigger update vertex position*)
+(*- Hover over edge/vertex should thicken it.*)
 
 
-IGGraphEditor[VertexSize->Small]
+IGGraphEditor[VertexSize->Small, "SnapToGrid"->True]
 
 
-(* ::Input:: *)
-(*\!\( *)
-(*TagBox[*)
-(*DynamicModuleBox[{IGraphM`GraphEditor`PackagePrivate`state$$ = <|"vertex" -> <|"4f62303b-bf36-48ec-9ed3-79d7d141e6c5" -> <|"name" -> 1, "id" -> "4f62303b-bf36-48ec-9ed3-79d7d141e6c5", "pos" -> {-0.5349999999999999, 0.3918525382413843}|>, "39d3f441-bbfe-4cfe-8c6b-04f4e193bb67" -> <|"name" -> 4, "id" -> "39d3f441-bbfe-4cfe-8c6b-04f4e193bb67", "pos" -> {0.45500000000000007`, -0.34314746175861577`}|>, "bdbcd0d0-01d5-46b2-a071-3c742217ee58" -> <|"name" -> 6, "id" -> "bdbcd0d0-01d5-46b2-a071-3c742217ee58", "pos" -> {0.18000000000000016`, -0.5931474617586158}|>, "45c84633-138c-433b-bb0d-2475b7fdb6f8" -> <|"name" -> 2, "id" -> "45c84633-138c-433b-bb0d-2475b7fdb6f8", "pos" -> {0.09499999999999997, 0.4968525382413843}|>, "046655c3-593a-446e-a681-2e2d5ba7ef9d" -> <|"name" -> 5, "id" -> "046655c3-593a-446e-a681-2e2d5ba7ef9d", "pos" -> {1.665, 0.23185253824138424`}|>, "dd43662b-914b-47e0-94ab-a38c924f28ae" -> <|"name" -> 7, "id" -> "dd43662b-914b-47e0-94ab-a38c924f28ae", "pos" -> {-0.2699999999999999, 0.44685253824138427`}|>|>, "edge" -> <|"e3" -> <|"v1" -> "046655c3-593a-446e-a681-2e2d5ba7ef9d", "v2" -> "dd43662b-914b-47e0-94ab-a38c924f28ae", "id" -> "e3", "type" -> UndirectedEdge["v1", "v2"], "shape" -> Automatic|>|>, "selectedVertex" -> Null, "version" -> 2, "KeepVertexCoordinates" -> True, "CreateVertexSelects" -> True, "SnapToGrid" -> False, "IndexGraph" -> False, "PerformanceLimit" -> 450, "VertexLabels" -> None, "VertexSize" -> Small, "DirectedEdges" -> False, "ImageSize" -> {300, 148.63636363636365`}, "vCounter" -> 6, "eCounter" -> 1, "range" -> {{-0.8099999999999999, 1.94}, {-0.7293974617586158, 0.6331025382413843}}, "aspectRatio" -> 2.018348623853211, "inRangeQ" -> RegionMemberFunction[MeshRegion[{{-0.8099999999999999, -0.7293974617586158}, {1.94, -0.7293974617586158}, {1.94, 0.6331025382413843}, {-0.8099999999999999, 0.6331025382413843}}, {Polygon[{{1, 2, 3, 4}}]}, Method -> {"EliminateUnusedCoordinates" -> True, "DeleteDuplicateCoordinates" -> Automatic, "DeleteDuplicateCells" -> Automatic, "VertexAlias" -> Identity, "CheckOrientation" -> Automatic, "CoplanarityTolerance" -> Automatic, "CheckIntersections" -> Automatic, "BoundaryNesting" -> Automatic, "SeparateBoundaries" -> Automatic, "TJunction" -> Automatic, "PropagateMarkers" -> True, "ZeroTest" -> Automatic, "Hash" -> 6068137075315393170}], 2, Region`Mesh`CanonicalDistance[True]], "snap" -> False, "realVertexSize" -> 0.03419170071312608|>, IGraphM`GraphEditor`PackagePrivate`error$$ = False, IGraphM`GraphEditor`PackagePrivate`refresh$$}, *)
-(*InterpretationBox[*)
-(*PaneSelectorBox[{True->*)
-(*ButtonBox[*)
-(*DynamicBox[ToBoxes[IGraphM`GraphEditor`PackagePrivate`error$$, StandardForm]],*)
-(*Appearance->Automatic,*)
-(*BaseStyle->15,*)
-(*ButtonFunction:>IGraphM`GraphEditor`PackagePrivate`refresh$$[],*)
-(*Evaluator->Automatic,*)
-(*Method->"Preemptive"], False->*)
-(*PanelBox[*)
-(*DynamicBox[ToBoxes[Refresh[IGraphM`GraphEditor`PackagePrivate`iGraphEditorPanel[Dynamic[IGraphM`GraphEditor`PackagePrivate`state$$]], None], StandardForm],*)
-(*ImageSizeCache->{300., {72.25177550659812, 76.38458812976553}}],*)
-(*BaseStyle->(CacheGraphics -> False),*)
-(*FrameMargins->0]}, Dynamic[MatchQ[Blank[Failure]][IGraphM`GraphEditor`PackagePrivate`error$$]],*)
-(*ImageSize->Automatic],*)
-(*IGraphM`GraphEditor`PackagePrivate`GraphFromEditorState[IGraphM`GraphEditor`PackagePrivate`state$$]],*)
-(*Deinitialization:>IGraphM`GraphEditor`PackagePrivate`iGraphEditorDeinitialization[IGraphM`GraphEditor`PackagePrivate`state$$],*)
-(*DynamicModuleValues:>{{UpValues[IGraphM`GraphEditor`PackagePrivate`state$$] = {HoldPattern[Condition[IGraphM`GraphEditor`PackagePrivate`state$$[Pattern[IGraphM`PreciseTracking`PackagePrivate`key$, Blank[]], Pattern[IGraphM`PreciseTracking`PackagePrivate`rest$, BlankNullSequence[]]] = Pattern[IGraphM`PreciseTracking`PackagePrivate`val$, Blank[]], Not[TrueQ[IGraphM`PreciseTracking`PackagePrivate`$inside$7851]]]] :> Block[{IGraphM`PreciseTracking`PackagePrivate`$inside$7851 = True, IGraphM`PreciseTracking`PackagePrivate`$old = IGraphM`GraphEditor`PackagePrivate`state$$[IGraphM`PreciseTracking`PackagePrivate`key$, IGraphM`PreciseTracking`PackagePrivate`rest$]}, IGraphM`GraphEditor`PackagePrivate`state$$[IGraphM`PreciseTracking`PackagePrivate`key$, IGraphM`PreciseTracking`PackagePrivate`rest$] = IGraphM`PreciseTracking`PackagePrivate`val$; If[IGraphM`PreciseTracking`PackagePrivate`$old =!= IGraphM`PreciseTracking`PackagePrivate`val$, IGraphM`PreciseTracking`PackagePrivate`UpdateTarget[IGraphM`GraphEditor`PackagePrivate`state$$[IGraphM`PreciseTracking`PackagePrivate`key$]]]; IGraphM`PreciseTracking`PackagePrivate`val$]}}, {DownValues[IGraphM`GraphEditor`PackagePrivate`refresh$$] = {HoldPattern[IGraphM`GraphEditor`PackagePrivate`refresh$$[]] :> Module[{IGraphM`GraphEditor`PackagePrivate`temp$}, Catch[If[Needs["IGraphM`"] === $Failed, Throw[IGraphM`GraphEditor`PackagePrivate`error$$ = Failure["GraphEditor", <|"Message" -> "\[WarningSign] Failed to load IGraphM`, make sure it is installed."|>]]]; IGraphM`GraphEditor`PackagePrivate`temp$ = IGraphM`GraphEditor`PackagePrivate`geStateVersionCheck[IGraphM`GraphEditor`PackagePrivate`state$$]; If[AssociationQ[IGraphM`GraphEditor`PackagePrivate`temp$], IGraphM`GraphEditor`PackagePrivate`state$$ = IGraphM`GraphEditor`PackagePrivate`temp$, Throw[IGraphM`GraphEditor`PackagePrivate`error$$ = IGraphM`GraphEditor`PackagePrivate`temp$]]; IGraphM`GraphEditor`PackagePrivate`iGraphEditorInitialization[IGraphM`GraphEditor`PackagePrivate`state$$, IGraphM`GraphEditor`PackagePrivate`error$$]]]}}},*)
-(*Initialization:>IGraphM`GraphEditor`PackagePrivate`refresh$$[]],*)
-(*Setting[#, {0}]& ]\)*)
+IGraphM`PreciseTracking`PackagePrivate`$TrackedTargets
 
 
 IGGraphEditor[ImageSize->100]
@@ -158,4 +137,7 @@ Graph[{1->2,2->1,3->1}]//SimpleGraphQ
 MultigraphQ
 
 
-PreciseTracking`Private`$TrackedTargets
+Names["*`$TrackedTargets"]
+
+
+IGraphM`PreciseTracking`PackagePrivate`$TrackedTargets

--- a/Tests/Editor.wl
+++ b/Tests/Editor.wl
@@ -6,7 +6,7 @@ toState = IGraphM`GraphEditor`PackagePrivate`GraphToEditorState;
 VerificationTest[
   {
     SetOptions[IGGraphEditor,ImageSize->200]
-  , toState[]["config", "ImageSize"]
+  , toState[][ "ImageSize"]
   , SetOptions[IGGraphEditor,ImageSize->Automatic]
   } [[2]]
 , 200
@@ -16,7 +16,7 @@ VerificationTest[
 
 VerificationTest[
   state = toState @ Graph[{1<->2}]
-; state["config", "DirectedEdges"]
+; state[ "DirectedEdges"]
 , False
 , TestID -> "Two way !directed"
 ]
@@ -24,7 +24,7 @@ VerificationTest[
 
 VerificationTest[
   state = toState @ Graph[{1, 2}, {}]
-; state["config", "DirectedEdges"]
+; state[ "DirectedEdges"]
 , False
 , TestID -> "Empty !directed"
 ]
@@ -32,14 +32,14 @@ VerificationTest[
 
 VerificationTest[
   state = toState @ Graph[{1->2, 2->1}]
-; state["config", "DirectedEdges"]
+; state[ "DirectedEdges"]
 , True
 , TestID -> "directed graph directed"
 ]
 
 
 VerificationTest[
-  config = toState[PathGraph[{1,2}, VertexLabels->"Index"],DirectedEdges->True, VertexLabels->"Name"]["config"]
+  config = toState[PathGraph[{1,2}, VertexLabels->"Index"],DirectedEdges->True, VertexLabels->"Name"]
 ; config["DirectedEdges"]
 , False
 , TestID -> "Input graph DirectedEdges > options DirectedEdges"
@@ -67,4 +67,14 @@ VerificationTest[
 ]
 , True
 , TestID -> "extractEdgePrimitives"
+]
+
+
+v1boxes = "1:eJzNWM1vG0UUd9pCS79IabkgVVqqHBDEleOPOC5SIXHi1tAEN3Z6QBwy3n22h6x3VjPjNO6FK/8BV/4JLhxKheDGGYkTQvAHgIQEt/LerL1rb9eOnfTAZT3rN+/799682bebYrd1JpVKqVfx0WDtDXHUOkfvi/jY7Husy+1t4fRcIMpZohD5AVc64KO/6qDVu/hbvSeZ39neNz9bDtdC7teYfcDaUJP8kGnYVxqfS0utV4j3Ej7WlRI2Z5oLLxBI4ndRX50sOgSp4SggTN+9hIuVQr5ZcnJOGor5fDpfyObT+J5PQ6aUKWSzzVyOOYEP02XRAj0HvoCLGI3euDO7unFuUu4LBSSYKH91fv/ym3//uPv5zb3txd7zpwlO5VvNlVzRzqbXSoVMOp9hq+kmg0x6daXJ1vKFZrGZXZ3LqTNTnZpJ3WxODX7jTtECnDa0UscbfZXewAVbg/PIYMHQdnquG9t5PkCLQhlJaSMw2Siet1uLx6t9ExcfA/iByrIQ0uEeAleZLQ3ZgxjDdVyUJeCWgKVubJ64/SIVjcf8hrgnuaOoGCrMVUnbqp4DR6agJm4jh2ogW0J2mWfDA97lmn+/8EIMLuMiMO8Ba4IbWLcjvCS1Azf4EzBq6132QsSvUIfg0uRmC/OpJhr4GvnRxS5A8iIaNRG+jHZKQkLqmfwwxneBcloWPU+DTIIt0WFIT71IJ3sk89oxneNv8m8D0x+eysWfn5d++uqfuzH65o9rX1y/uPCd5KZIf43jmaDElI9x2CUsBc6k/vwgwVju7ZI5D4N6vUEkaCP8tqHbBFnpebYBo6FSFrZBdYIdQMLODQpsaPHQsqHh8fehwcP9oQMLY+Ewb1Q/NeH226h/nHxu9K1KtBXzzJpnzjzz486a02QbdEc4rSvJoTcxeQsXWy7ilYprz+spcGYoNuLaxALTsNnzXW7j3lEuQtt6T4suZsOOsd5IYAXXnc50KayHdZczpSiTVQc8zXU/oRTLHbAPPpEcN5jecqxBZeG7zGMSxTWEC5KKeCrTG0MtVUK+AoOa6T68josNrBSHyf4OYN157WNV1MFnEiM04OPHxJZojY8GGJ660zQsKXzWRunbTB6gE5OSTcH+FKRooNFThdLiPlOdKvXildxaJrtaLKyUcqViLrNSKmWCBmKgfTMsvH2qsP0y8/DUsJm7iRA10Z9gjCkF7NsTOx2dV3gMuFH7lOlnv7z/7W9f3z3RuARSCrm0FOlTy7MxSmhJdA0nLaP2GnERWHwJASrDcY6QUWMeBEeWkESY0C5NaYehoRo3GdnoaR0IXBg2rsHkGMqi7tIQ+IoYmtN1OrXqmBVEoFPBIy4aBskcLGbWB0ddDe0Iuyh14ROGK3TWuMcU1HXfBU6him0gZ9d9H9ixVWtoW4fM7TE0YOrOqHuas7gmAbq+5ocxtI2g0GTywiCT7qypiP7YDfwPuPKzxYyP0Iza6CAZ6JzzUhDOIxNyHvpN5IrEWRZ7R5t7KuHsH89cjEZHUpnZHTA2oZ0jkYz7YP4I/jVpYdruPAzeiWkDO/eB2V9h3O1hEOeDd4LV4aQUw4jRWZxNuiFVpOgG5DoFeN4r2sQ6q3o4XzKXP2GnrbO49Oup2KXzEZYL4jRhXkm8hY6gXjz2Aub5TUuQHzM02EJ/3heuU2MaO+upAmGgZTwe167emU2cxgaxFKGyTChtESqVmRVE16czfOsI279S4X2HHtVWsDZTPpbUCLZ3AFNiDuChBQboS4T0YQxoX6MjxePTHG9RHxoUkRm5RviieE++s503TVMpKp47uP7sTqWYLViBsZYWliuYYw2NWra67AAshcosri2uLOwjGi854Nwed2X+DKzOxoF26uDCSBkx89y8JXp2JItG9eXxED2cz/pTfNA5IVBPDZ0TODiK+vMGZ3RvlxGcam5vcDTOF4ORjwxjV9eXIQtekqykbwX/50reiyq5IQQWrde36KMgx2HLwgHBoi9J6rZV9WxMowLrVty7W5bwSQm1AC37yNR/zPq3TwW62Pj/3qwFv24mU5OEPd+JvhbRZ5Gw79ORcqKzel4zroVmmM839Q7zR8/ak9hhmAmv4RQeAgLDTLfOSH7dFZpH01X4RYiO0f8ACXE0ew==";
+
+
+VerificationTest[
+  ToExpression@Uncompress@v1boxes
+, Graph[{1, 2}, {}, {VertexCoordinates -> {{0.00001, -0.000030000000000000004}, {0.00001, -0.00001}}}]
+, TestID -> "Handling legacy typeset"
 ]


### PR DESCRIPTION
 - [x] reduces amount of events that used to fire because of limited control the FE gives us
 - [x] introduces mini feature that allows smarter updating of dynamic objects, mutations of `state[key] = val` kind don't trigger every object associated with `state` anymore  